### PR TITLE
Improved user agent list in config.xml

### DIFF
--- a/source/app/code/community/Yireo/DisableLog/etc/config.xml
+++ b/source/app/code/community/Yireo/DisableLog/etc/config.xml
@@ -48,7 +48,6 @@
             <hosttracker>HostTracker.com</hosttracker>
             <yahoo>ysearch/slurp</yahoo>
             <baidu>Baiduspider</baidu>
-            <yandex>YandexBot</yandex>
             <socialmedia>SocialMedia Bot</socialmedia>
             <exabot>Exabot</exabot>
             <soso>Sosospider+</soso>

--- a/source/app/code/community/Yireo/DisableLog/etc/config.xml
+++ b/source/app/code/community/Yireo/DisableLog/etc/config.xml
@@ -75,7 +75,10 @@
             <gigabot>Gigabot/</gigabot>
             <search17>Search17Bot</search17>
             <mj12>MJ12bot</mj12>
-            <misc>Bot,Robot,Spider,Crawler</misc>
+            <misc1>Bot</misc1>
+            <misc2>Robot</misc2>
+            <misc3>Spider</misc3>
+            <misc4>Crawler</misc4>
             <discobot>discobot/</discobot>
             <legs80>80legs.com/webcrawler</legs80>
             <kiwistatus>KiwiStatus/</kiwistatus>

--- a/source/app/code/community/Yireo/DisableLog/etc/config.xml
+++ b/source/app/code/community/Yireo/DisableLog/etc/config.xml
@@ -64,6 +64,7 @@
             <huawei>Huaweisymantecspider</huawei>
             <docomo>DoCoMo/</docomo>
             <msn>msnbot/</msn>
+            <msnbotmedia>msnbot-media/</msnbotmedia>
             <worio>woriobot support</worio>
             <archiver>ia_archiver</archiver>
             <passwordthumbs>1PasswordThumbs</passwordthumbs>
@@ -85,6 +86,37 @@
             <pycurl>PycURL/</pycurl>
             <voyager>Voyager/</voyager>
             <dowjones>Dow Jones Searchbot</dowjones>
+            <ahrefs>AhrefsBot/</ahrefs>
+            <beslist>BeslistBot/</beslist>
+            <cartdown>CartDown.com</cartdown>
+            <curl>curl/</curl>
+            <daisycon>Daisycon.com/bot</daisycon>
+            <facebookexternalhit>facebookexternalhit/</facebookexternalhit>
+            <googleadsbot>AdsBot-Google</googleadsbot>
+            <googleimageproxy>GoogleImageProxy</googleimageproxy>
+            <googleshoppingquality>Google-Shopping-Quality</googleshoppingquality>
+            <img_cache>IMG CACHE</img_cache>
+            <imgix>imgix/</imgix>
+            <kieskeurig>Kieskeurig</kieskeurig>
+            <klezzer>Klezzer</klezzer>
+            <ltx71>ltx71</ltx71>
+            <megaindex>MegaIndex.ru</megaindex>
+            <nagios>nagios</nagios>
+            <newrelicpinger>NewRelicPinger/</newrelicpinger>
+            <okhttp>okhttp/</okhttp>
+            <openoffice>Apache OpenOffice/</openoffice>
+            <pinterest>Pinterest/</pinterest>
+            <pretzel>pretzel/imagefly</pretzel>
+            <ruby>Ruby</ruby>
+            <semrushbot>SemrushBot/</semrushbot>
+            <seoscanners>seoscanners.net</seoscanners>
+            <swcd>swcd</swcd>
+            <uptimerobot>UptimeRobot/</uptimerobot>
+            <webmeup>BLEXBot/</webmeup>
+            <weserv>ImageFetcher/</weserv>
+            <wiseguys>Vagabondo/</wiseguys>
+            <yandex>Yandex</yandex>
+            <yandex_directfetcher>YaDirectFetcher/</yandex_directfetcher>
         </skip_user_agents>
     </global>
 

--- a/source/app/code/community/Yireo/DisableLog/etc/config.xml
+++ b/source/app/code/community/Yireo/DisableLog/etc/config.xml
@@ -75,10 +75,9 @@
             <gigabot>Gigabot/</gigabot>
             <search17>Search17Bot</search17>
             <mj12>MJ12bot</mj12>
-            <misc1>Bot</misc1>
-            <misc2>Robot</misc2>
-            <misc3>Spider</misc3>
-            <misc4>Crawler</misc4>
+            <misc1>Robot</misc1>
+            <misc2>Spider</misc2>
+            <misc3>Crawler</misc3>
             <discobot>discobot/</discobot>
             <legs80>80legs.com/webcrawler</legs80>
             <kiwistatus>KiwiStatus/</kiwistatus>

--- a/source/app/code/community/Yireo/DisableLog/etc/config.xml
+++ b/source/app/code/community/Yireo/DisableLog/etc/config.xml
@@ -56,20 +56,20 @@
             <comodo1>Comodo-Certificates-Spider</comodo1>
             <comodo2>Comodo SSL Checker</comodo2>
             <speedy>Speedy Spider</speedy>
-            <twitter>Twitterbot/0.1</twitter>
+            <twitter>Twitterbot/</twitter>
             <sitespeed>SiteSpeedBot</sitespeed>
-            <zooka>Zookabot/2.1;++http://zookabot.com</zooka>
+            <zooka>Zookabot/</zooka>
             <njuice>NjuiceBot</njuice>
-            <friendfeed>FriendFeedBot/0.1</friendfeed>
+            <friendfeed>FriendFeedBot/</friendfeed>
             <huawei>Huaweisymantecspider</huawei>
-            <docomo>DoCoMo/2.0</docomo>
+            <docomo>DoCoMo/</docomo>
             <msn>msnbot/</msn>
             <worio>woriobot support</worio>
             <archiver>ia_archiver</archiver>
             <passwordthumbs>1PasswordThumbs</passwordthumbs>
             <twingly>Twingly Recon</twingly>
-            <tlsprober>TLSProber/0.1</tlsprober>
-            <postrank>PostRank/2.0 (postrank.com)</postrank>
+            <tlsprober>TLSProber/</tlsprober>
+            <postrank>PostRank/</postrank>
             <jskit1>JS-Kit URL Resolver, http://js-kit.com/</jskit1>
             <dotnetcom>dotnetdotcom.org</dotnetcom>
             <gigabot>Gigabot/</gigabot>


### PR DESCRIPTION
This Pull Request adds several new bot strings, and solves a few small issues in the plugin:
1. A number of strings had version numbers embedded in them. This was an issue for at least Zookabot, of which other versions are known, and TwitterBot, version 1.0 of which I have personally seen in the wild. There may, of course, be others, so I've removed all version strings in the nodes.
2. There was a `<misc>` node, which contained a comma-separated list of generic strings. However, there seems to be no code anywhere in the plugin that actually explodes the node text. I chose to fix the issue by splitting the node.
3. The string "bot" seems too generic; there are several words in many languages this will match, so it may clash with a genuine browser string. Several user agents these days contain OEM strings, so even if a browser name doesn't contain "bot", a user agent string may still match. I've removed the "bot" node.

Can you please take a look and merge, or let me know if there's something you'd like altered? I'd be happy to accommodate and make a new PR if you want.

Thanks in advance!
