### PR TITLE
Fixed wrong module name

### DIFF
--- a/source/app/code/community/Yireo/DisableLog/etc/system.xml
+++ b/source/app/code/community/Yireo/DisableLog/etc/system.xml
@@ -11,7 +11,7 @@
 -->
 <config>
     <tabs>
-        <yireo translate="label" module="deleteanyorder">
+        <yireo translate="label" module="disablelog">
             <label>Yireo</label>
             <sort_order>1000</sort_order>
         </yireo>


### PR DESCRIPTION
Magento Backend Configuration Page is broken (blank white page) because of incorrect module name
